### PR TITLE
DTSPO-14061 Support to override custom script extension name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_computer_name"></a> [computer\_name](#input\_computer\_name) | Override the computer name of the VM. If not set, the computer name will be the same as the VM name truncated to 15 characters (Windows only). | `any` | `null` | no |
 | <a name="input_custom_data"></a> [custom\_data](#input\_custom\_data) | Custom data to pass to the virtual machine. | `string` | `null` | no |
 | <a name="input_custom_image_id"></a> [custom\_image\_id](#input\_custom\_image\_id) | The ID of a custom image to use. | `string` | `""` | no |
+| <a name="input_custom_script_extension_name"></a> [custom\_script\_extension\_name](#input\_custom\_script\_extension\_name) | Overwrite custom script extension name label in bootstrap module. | `string` | `null` | no |
 | <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | DNS servers to use, will override DNS servers set at the VNET level | `list(string)` | `null` | no |
 | <a name="input_dynatrace_hostgroup"></a> [dynatrace\_hostgroup](#input\_dynatrace\_hostgroup) | The hostgroup to place the virtual machine in within DynaTrace | `string` | `null` | no |
 | <a name="input_dynatrace_server"></a> [dynatrace\_server](#input\_dynatrace\_server) | The Dynatrace ActiveGate server URL. | `string` | `null` | no |

--- a/extensions.tf
+++ b/extensions.tf
@@ -26,8 +26,8 @@ module "vm-bootstrap" {
   rc_script_file = var.rc_script_file
   rc_os_sku      = var.rc_os_sku
 
-  additional_script_uri  = var.additional_script_uri
-  additional_script_name = var.additional_script_name
-
-  common_tags = var.tags
+  additional_script_uri        = var.additional_script_uri
+  additional_script_name       = var.additional_script_name
+  custom_script_extension_name = var.custom_script_extension_name
+  common_tags                  = var.tags
 }

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -271,3 +271,9 @@ variable "systemassigned_identity" {
   description = "Enable System Assigned managed identity for the virtual machine."
   default     = false
 }
+
+variable "custom_script_extension_name" {
+  description = "Overwrite custom script extension name label in bootstrap module."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14061

Adding support to override this variable that's set as a default in https://github.com/hmcts/terraform-module-vm-bootstrap/blob/master/variables.tf#L78-L82

I want to name these relative to my application - in all cases it defaults to null unless provided, and will default to `HMCTSVMBootstrap` as normal in the bootstrap module. Optional var that defaults to null shouldn't cause issues for any current module consumers


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
