### PR TITLE
DTSPO-14061 Add install-app-proxy functionality to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vm-bootstrap"></a> [vm-bootstrap](#module\_vm-bootstrap) | git::https://github.com/hmcts/terraform-module-vm-bootstrap.git | master |
+| <a name="module_vm-bootstrap"></a> [vm-bootstrap](#module\_vm-bootstrap) | git::https://github.com/hmcts/terraform-module-vm-bootstrap.git | DTSPO-14061-Add-app-proxy-script |
 
 ## Resources
 

--- a/extensions.tf
+++ b/extensions.tf
@@ -16,6 +16,7 @@ module "vm-bootstrap" {
   install_dynatrace_oneagent = var.install_dynatrace_oneagent
   install_azure_monitor      = var.install_azure_monitor
   install_nessus_agent       = var.nessus_install
+  install_app_proxy          = var.install_app_proxy
 
   dynatrace_hostgroup = var.dynatrace_hostgroup
   dynatrace_server    = var.dynatrace_server
@@ -25,7 +26,6 @@ module "vm-bootstrap" {
   run_command    = var.run_command
   rc_script_file = var.rc_script_file
   rc_os_sku      = var.rc_os_sku
-
   additional_script_uri        = var.additional_script_uri
   additional_script_name       = var.additional_script_name
   custom_script_extension_name = var.custom_script_extension_name

--- a/extensions.tf
+++ b/extensions.tf
@@ -1,7 +1,7 @@
 
 module "vm-bootstrap" {
   count  = var.install_splunk_uf == true || var.nessus_install == true ? 1 : 0
-  source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=DTSPO-14061-Add-app-proxy-script"
 
   virtual_machine_type       = "vm"
   virtual_machine_id         = var.vm_type == "linux" ? azurerm_linux_virtual_machine.linvm[0].id : azurerm_windows_virtual_machine.winvm[0].id

--- a/extensions.tf
+++ b/extensions.tf
@@ -23,9 +23,9 @@ module "vm-bootstrap" {
   dynatrace_tenant_id = var.dynatrace_tenant_id
   dynatrace_token     = var.dynatrace_token
 
-  run_command    = var.run_command
-  rc_script_file = var.rc_script_file
-  rc_os_sku      = var.rc_os_sku
+  run_command                  = var.run_command
+  rc_script_file               = var.rc_script_file
+  rc_os_sku                    = var.rc_os_sku
   additional_script_uri        = var.additional_script_uri
   additional_script_name       = var.additional_script_name
   custom_script_extension_name = var.custom_script_extension_name

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -277,3 +277,9 @@ variable "custom_script_extension_name" {
   type        = string
   default     = null
 }
+
+variable "install_app_proxy" {
+  description = "Install Azure App Proxy."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
This is being used in https://github.com/hmcts/terraform-module-vm-bootstrap/pull/31 -- but we call this child module indirectly in azure-app-proxy through this module, so we need to add support to pass it through too

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
