### PR TITLE
DTSPO-18803-Migrate-Glimr-servers-to-AMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vm-bootstrap"></a> [vm-bootstrap](#module\_vm-bootstrap) | git::https://github.com/hmcts/terraform-module-vm-bootstrap.git | master |
+| <a name="module_vm-bootstrap"></a> [vm-bootstrap](#module\_vm-bootstrap) | git::https://github.com/hmcts/terraform-module-vm-bootstrap.git | ieuanb74-patch-1 |
 
 ## Resources
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -3,6 +3,7 @@ module "virtual-machine" {
     azurerm     = azurerm
     azurerm.cnp = azurerm.cnp
     azurerm.soc = azurerm.soc
+    azurerm.dcr = azurerm.dcr
   }
 
   source = "../"

--- a/example/provider.tf
+++ b/example/provider.tf
@@ -13,3 +13,10 @@ provider "azurerm" {
   features {}
   subscription_id = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
 }
+
+provider "azurerm" {
+  alias                      = "dcr"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = var.env == "prod" || var.env == "production" ? "8999dec3-0104-4a27-94ee-6588559729d1" : var.env == "sbox" || var.env == "sandbox" ? "bf308a5c-0624-4334-8ff8-8dca9fd43783" : "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+}

--- a/extensions.tf
+++ b/extensions.tf
@@ -4,10 +4,11 @@ module "vm-bootstrap" {
     azurerm     = azurerm
     azurerm.cnp = azurerm.cnp
     azurerm.soc = azurerm.soc
+    azurerm.dcr = azurerm.dcr
   }
 
   count  = var.install_splunk_uf == true || var.nessus_install == true || var.run_command == true ? 1 : 0
-  source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=ieuanb74-patch-1"
 
   virtual_machine_type       = "vm"
   virtual_machine_id         = lower(var.vm_type) == "linux" ? azurerm_linux_virtual_machine.linvm[0].id : azurerm_windows_virtual_machine.winvm[0].id

--- a/networking.tf
+++ b/networking.tf
@@ -1,9 +1,9 @@
 resource "azurerm_network_interface" "vm_nic" {
-  name                          = var.nic_name == null ? "${var.vm_name}-nic" : var.nic_name
-  location                      = var.vm_location
-  resource_group_name           = var.vm_resource_group
-  enable_accelerated_networking = var.accelerated_networking_enabled
-  dns_servers                   = var.dns_servers
+  name                           = var.nic_name == null ? "${var.vm_name}-nic" : var.nic_name
+  location                       = var.vm_location
+  resource_group_name            = var.vm_resource_group
+  accelerated_networking_enabled = var.accelerated_networking_enabled
+  dns_servers                    = var.dns_servers
 
   ip_configuration {
     name                          = var.ipconfig_name == null ? "${var.vm_name}-ipconfig" : var.ipconfig_name

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      configuration_aliases = [azurerm.cnp, azurerm.soc]
+      configuration_aliases = [azurerm.cnp, azurerm.soc, azurerm.dcr]
     }
   }
 }

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -19,6 +19,13 @@ provider "azurerm" {
   resource_provider_registrations = "none"
 }
 
+provider "azurerm" {
+  alias                      = "dcr"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = var.env == "prod" || var.env == "production" ? "8999dec3-0104-4a27-94ee-6588559729d1" : var.env == "sbox" || var.env == "sandbox" ? "bf308a5c-0624-4334-8ff8-8dca9fd43783" : "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+}
+
 # Default variables for this test
 variables {
   env                  = "nonprod"

--- a/tests/networking.tftest.hcl
+++ b/tests/networking.tftest.hcl
@@ -19,6 +19,13 @@ provider "azurerm" {
   resource_provider_registrations = "none"
 }
 
+provider "azurerm" {
+  alias                      = "dcr"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = var.env == "prod" || var.env == "production" ? "8999dec3-0104-4a27-94ee-6588559729d1" : var.env == "sbox" || var.env == "sandbox" ? "bf308a5c-0624-4334-8ff8-8dca9fd43783" : "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+}
+
 # Default variables for this test
 variables {
   env                  = "nonprod"

--- a/tests/vm_name.tftest.hcl
+++ b/tests/vm_name.tftest.hcl
@@ -19,6 +19,13 @@ provider "azurerm" {
   resource_provider_registrations = "none"
 }
 
+provider "azurerm" {
+  alias                      = "dcr"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = var.env == "prod" || var.env == "production" ? "8999dec3-0104-4a27-94ee-6588559729d1" : var.env == "sbox" || var.env == "sandbox" ? "bf308a5c-0624-4334-8ff8-8dca9fd43783" : "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+}
+
 # Default variables for this test
 variables {
   env                  = "nonprod"

--- a/tests/vm_type.tftest.hcl
+++ b/tests/vm_type.tftest.hcl
@@ -19,6 +19,13 @@ provider "azurerm" {
   resource_provider_registrations = "none"
 }
 
+provider "azurerm" {
+  alias                      = "dcr"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = var.env == "prod" || var.env == "production" ? "8999dec3-0104-4a27-94ee-6588559729d1" : var.env == "sbox" || var.env == "sandbox" ? "bf308a5c-0624-4334-8ff8-8dca9fd43783" : "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+}
+
 # Default variables for this test
 variables {
   vm_name              = "example-vm"


### PR DESCRIPTION
### Jira link

[DTSPO-18803](https://tools.hmcts.net/jira/browse/DTSPO-18803)

### Change description

Installing ama agent on non-prod Glimr servers

