### PR TITLE
Pass install splunk flag to bootstrap module

### DIFF
--- a/extensions.tf
+++ b/extensions.tf
@@ -23,6 +23,7 @@ module "vm-bootstrap" {
   install_dynatrace_oneagent = var.install_dynatrace_oneagent
   install_azure_monitor      = var.install_azure_monitor
   install_nessus_agent       = var.nessus_install
+  install_splunk_uf          = var.install_splunk_uf
 
 
   dynatrace_hostgroup = var.dynatrace_hostgroup


### PR DESCRIPTION
This causes a bug where, as `install_splunk_uf` defaults to true in the boot strap module, unwanted extensions can be installed with clients unable to control that flow. For example, not wanting to run the custom_script as you want to run your own but Windows VMs only allow 1 instance...