### PR TITLE
DTSPO-22154 - added config to set availablity sets for the VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 
 | Name | Type |
 |------|------|
+| [azurerm_availability_set.set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/availability_set) | resource |
 | [azurerm_disk_encryption_set.disk_enc_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/disk_encryption_set) | resource |
 | [azurerm_key_vault_access_policy.disk_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.disk_enc_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
@@ -59,6 +60,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_additional_script_name"></a> [additional\_script\_name](#input\_additional\_script\_name) | The path to a script to run against the virtual machine. | `string` | `null` | no |
 | <a name="input_additional_script_uri"></a> [additional\_script\_uri](#input\_additional\_script\_uri) | URI of a publically accessible script to run against the virtual machine. | `string` | `null` | no |
 | <a name="input_aum_schedule_enable"></a> [aum\_schedule\_enable](#input\_aum\_schedule\_enable) | Specifies whether to skip platform scheduled patching when a user schedule is associated with the VM. Defaults to false. HMCTS use this to set AUM as Customer Managed Schedules | `bool` | `true` | no |
+| <a name="input_availability_set_name"></a> [availability\_set\_name](#input\_availability\_set\_name) | Name of the availability\_set | `string` | `""` | no |
 | <a name="input_boot_diagnostics_enabled"></a> [boot\_diagnostics\_enabled](#input\_boot\_diagnostics\_enabled) | Whether to enable boot diagnostics. | `bool` | `true` | no |
 | <a name="input_boot_storage_uri"></a> [boot\_storage\_uri](#input\_boot\_storage\_uri) | The URI of the storage to use for boot diagnostics. | `string` | `null` | no |
 | <a name="input_computer_name"></a> [computer\_name](#input\_computer\_name) | Override the computer name of the VM. If not set, the computer name will be the same as the VM name truncated to 15 characters (Windows only). | `any` | `null` | no |
@@ -71,6 +73,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_dynatrace_server"></a> [dynatrace\_server](#input\_dynatrace\_server) | The Dynatrace ActiveGate server URL. | `string` | `null` | no |
 | <a name="input_dynatrace_tenant_id"></a> [dynatrace\_tenant\_id](#input\_dynatrace\_tenant\_id) | The Dynatrace tenant ID. | `string` | `""` | no |
 | <a name="input_dynatrace_token"></a> [dynatrace\_token](#input\_dynatrace\_token) | The token to use when communicating with the Dynatrace ActiveGate. | `string` | `""` | no |
+| <a name="input_enable_availability_set"></a> [enable\_availability\_set](#input\_enable\_availability\_set) | Enable availability set or not, default is false | `bool` | `false` | no |
 | <a name="input_encrypt_CMK"></a> [encrypt\_CMK](#input\_encrypt\_CMK) | Encrypt the disks with a customer-managed key. | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment name | `string` | n/a | yes |
 | <a name="input_install_azure_monitor"></a> [install\_azure\_monitor](#input\_install\_azure\_monitor) | Install Azure Monitor Agent. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | The operating system disk size in GB. | `string` | `"128"` | no |
 | <a name="input_os_disk_storage_account_type"></a> [os\_disk\_storage\_account\_type](#input\_os\_disk\_storage\_account\_type) | The operating system disk storack account type. | `string` | `"StandardSSD_LRS"` | no |
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | The operating system disk type. | `string` | `"ReadWrite"` | no |
+| <a name="input_platform_fault_domain_count"></a> [platform\_fault\_domain\_count](#input\_platform\_fault\_domain\_count) | Specifies the number of fault domains that are used. Defaults to 2 | `number` | `2` | no |
 | <a name="input_privateip_allocation"></a> [privateip\_allocation](#input\_privateip\_allocation) | The type of private IP allocation, either Static or Dynamic. | `string` | `"Static"` | no |
 | <a name="input_provision_vm_agent"></a> [provision\_vm\_agent](#input\_provision\_vm\_agent) | If patch\_assessment\_mode AutomaticByPlatform then the provision\_vm\_agent field must be set to true. | `bool` | `true` | no |
 | <a name="input_rc_os_sku"></a> [rc\_os\_sku](#input\_rc\_os\_sku) | The SKU of run command to use. | `string` | `null` | no |

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -368,3 +368,15 @@ variable "xdr_tags" {
   type        = string
   default     = ""
 }
+
+variable "enable_availability_set" {
+  description = "Enable availability set or not, default is false"
+  type        = bool
+  default     = false
+}
+
+variable "availability_set_name" {
+  description = "Name of the availability_set"
+  type        = string
+  default     = ""
+}

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -380,3 +380,9 @@ variable "availability_set_name" {
   type        = string
   default     = ""
 }
+
+variable "platform_fault_domain_count" {
+  description = "Specifies the number of fault domains that are used. Defaults to 2"
+  type        = number
+  default     = 2
+}

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_windows_virtual_machine" "winvm" {
   network_interface_ids = [
     azurerm_network_interface.vm_nic.id,
   ]
-
+  availability_set_id = var.enable_availability_set ? azurerm_availability_set.set.id : null
   os_disk {
     caching                = var.os_disk_type
     storage_account_type   = var.os_disk_storage_account_type
@@ -93,7 +93,7 @@ resource "azurerm_linux_virtual_machine" "linvm" {
   provision_vm_agent                                     = var.provision_vm_agent
   patch_mode                                             = var.vm_patch_mode
   bypass_platform_safety_checks_on_user_schedule_enabled = var.aum_schedule_enable
-
+  availability_set_id                                    = var.enable_availability_set ? azurerm_availability_set.set.id : null
   source_image_reference {
 
     publisher = var.vm_publisher_name
@@ -129,4 +129,14 @@ resource "azurerm_linux_virtual_machine" "linvm" {
 
   tags       = var.tags
   depends_on = [azurerm_disk_encryption_set.disk_enc_set]
+}
+
+
+resource "azurerm_availability_set" "set" {
+  count               = var.enable_availability_set ? 1 : 0
+  name                = var.availability_set_name
+  location            = var.vm_location
+  resource_group_name = var.vm_resource_group
+
+  tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_windows_virtual_machine" "winvm" {
   network_interface_ids = [
     azurerm_network_interface.vm_nic.id,
   ]
-  availability_set_id = var.enable_availability_set ? azurerm_availability_set.set.id : null
+  availability_set_id = var.enable_availability_set ? azurerm_availability_set.set[0].id : null
   os_disk {
     caching                = var.os_disk_type
     storage_account_type   = var.os_disk_storage_account_type
@@ -93,7 +93,7 @@ resource "azurerm_linux_virtual_machine" "linvm" {
   provision_vm_agent                                     = var.provision_vm_agent
   patch_mode                                             = var.vm_patch_mode
   bypass_platform_safety_checks_on_user_schedule_enabled = var.aum_schedule_enable
-  availability_set_id                                    = var.enable_availability_set ? azurerm_availability_set.set.id : null
+  availability_set_id                                    = var.enable_availability_set ? azurerm_availability_set.set[0].id : null
   source_image_reference {
 
     publisher = var.vm_publisher_name

--- a/main.tf
+++ b/main.tf
@@ -133,10 +133,10 @@ resource "azurerm_linux_virtual_machine" "linvm" {
 
 
 resource "azurerm_availability_set" "set" {
-  count               = var.enable_availability_set ? 1 : 0
-  name                = var.availability_set_name
-  location            = var.vm_location
-  resource_group_name = var.vm_resource_group
-
-  tags = var.tags
+  count                       = var.enable_availability_set ? 1 : 0
+  name                        = var.availability_set_name
+  location                    = var.vm_location
+  resource_group_name         = var.vm_resource_group
+  platform_fault_domain_count = var.platform_fault_domain_count
+  tags                        = var.tags
 }


### PR DESCRIPTION
### Jira link


See [Jira](https://tools.hmcts.net/jira/browse/DTSPO-22154)

### Change description
Following changes has been added to this PR
 - allows setting azurerm_availability_set from this module.  Its optional setting so it will not affect any existing consumers.

### Testing done

Testing done on the test repo below, with availability set and without availability set - 
[pipeline](https://dev.azure.com/hmcts/PlatformOperations/_build?definitionId=993&_a=summary)

[Repository](https://github.com/hmcts/terraform-kt)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

