### PR TITLE
Allows to pass in OS disk name to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_nessus_key"></a> [nessus\_key](#input\_nessus\_key) | The key to use when communicating with Tenable Nessus. | `string` | `null` | no |
 | <a name="input_nessus_server"></a> [nessus\_server](#input\_nessus\_server) | The Tenable Nessus server URL. | `string` | `""` | no |
 | <a name="input_nic_name"></a> [nic\_name](#input\_nic\_name) | The name of the NIC to create & associate with the virtual machine. | `string` | `null` | no |
+| <a name="input_os_disk_name"></a> [os\_disk\_name](#input\_os\_disk\_name) | Name of the OS disk | `string` | `null` | no |
 | <a name="input_os_disk_size_gb"></a> [os\_disk\_size\_gb](#input\_os\_disk\_size\_gb) | The operating system disk size in GB. | `string` | `"128"` | no |
 | <a name="input_os_disk_storage_account_type"></a> [os\_disk\_storage\_account\_type](#input\_os\_disk\_storage\_account\_type) | The operating system disk storack account type. | `string` | `"StandardSSD_LRS"` | no |
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | The operating system disk type. | `string` | `"ReadWrite"` | no |

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -392,3 +392,9 @@ variable "platform_fault_domain_count" {
   type        = number
   default     = 2
 }
+
+variable "os_disk_name" {
+  description = "Name of the OS disk"
+  type        = string
+  default     = null
+}

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "azurerm_windows_virtual_machine" "winvm" {
   ]
   availability_set_id = var.enable_availability_set ? azurerm_availability_set.set[0].id : null
   os_disk {
+    name                   = var.os_disk_name
     caching                = var.os_disk_type
     storage_account_type   = var.os_disk_storage_account_type
     disk_encryption_set_id = var.encrypt_CMK ? azurerm_disk_encryption_set.disk_enc_set[0].id : null
@@ -83,6 +84,7 @@ resource "azurerm_linux_virtual_machine" "linvm" {
   ]
 
   os_disk {
+    name                   = var.os_disk_name
     caching                = var.os_disk_type
     storage_account_type   = var.os_disk_storage_account_type
     disk_encryption_set_id = var.encrypt_CMK ? azurerm_disk_encryption_set.disk_enc_set[0].id : null


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24632 

### Change description

Allows passing in OS disk name for Linux or Windows VM, by default its null so no impact on existing consumers.

### Testing done

Tested this branch here 

https://github.com/hmcts/ccd-module-elastic-search/pull/5/files#diff-940d0f2aa7b62d5752c99acbc96ddc6521a5d5dac79bbb3f9cb9e9a56922b111R9 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
