### PR TITLE
pass flag to bootstrap module for splunk removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_rbac_config"></a> [rbac\_config](#input\_rbac\_config) | Map containing the RBAC configuration for the VM | <pre>map(object({<br/>    scope                = string<br/>    role_definition_name = string<br/>    principal_id         = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_rc_os_sku"></a> [rc\_os\_sku](#input\_rc\_os\_sku) | The SKU of run command to use. | `string` | `null` | no |
 | <a name="input_rc_script_file"></a> [rc\_script\_file](#input\_rc\_script\_file) | The path to the script file to run against the virtual machine. | `string` | `null` | no |
+| <a name="input_remove_splunk_uf"></a> [remove\_splunk\_uf](#input\_remove\_splunk\_uf) | Remove Splunk UF if it is installed. Overrides install\_splunk\_uf if set to true. | `bool` | `false` | no |
 | <a name="input_run_cis"></a> [run\_cis](#input\_run\_cis) | Install CIS hardening using run command script? | `bool` | `false` | no |
 | <a name="input_run_command"></a> [run\_command](#input\_run\_command) | Run a custom command/script against the virtual machine using a run command extension. | `bool` | `false` | no |
 | <a name="input_run_command_sa_key"></a> [run\_command\_sa\_key](#input\_run\_command\_sa\_key) | SA key for the run command | `string` | `""` | no |

--- a/extensions.tf
+++ b/extensions.tf
@@ -7,7 +7,7 @@ module "vm-bootstrap" {
     azurerm.dcr = azurerm.dcr
   }
 
-  count  = var.install_splunk_uf == true || var.nessus_install == true || var.run_command == true || var.install_azure_monitor == true ? 1 : 0
+  count  = var.remove_splunk_uf == true || var.install_splunk_uf == true || var.nessus_install == true || var.run_command == true || var.install_azure_monitor == true ? 1 : 0
   source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=master"
 
   virtual_machine_type       = "vm"
@@ -26,6 +26,7 @@ module "vm-bootstrap" {
   install_nessus_agent       = var.nessus_install
   install_docker             = var.install_docker
   install_splunk_uf          = var.install_splunk_uf
+  remove_splunk_uf           = var.remove_splunk_uf
   enable_winrm               = var.enable_winrm
 
   dynatrace_hostgroup = var.dynatrace_hostgroup

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -170,6 +170,12 @@ variable "install_splunk_uf" {
   default     = true
 }
 
+variable "remove_splunk_uf" {
+  type = bool
+  description = "Remove Splunk UF if it is installed. Overrides install_splunk_uf if set to true."
+  default = false
+}
+
 variable "splunk_username" {
   type        = string
   description = "Splunk universal forwarder local admin username."


### PR DESCRIPTION
This is to fix a bug introduced in the bootstrap module here: https://github.com/hmcts/terraform-module-vm-bootstrap/commit/aca1c9d802b645775fe6b606142cd55f134e7739
This results in `remove_splunk_uf` always being true as the default value in bootstrap and forcing a custom script to be installed to remove splunk, even if the vm module consuming the bootstrap sets `install_splunk_uf` to true