### PR TITLE
DTSPO-31651: add backup enrollment via service_criticality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | Name | Type |
 |------|------|
 | [azurerm_availability_set.set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/availability_set) | resource |
+| [azurerm_backup_protected_vm.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/backup_protected_vm) | resource |
 | [azurerm_disk_encryption_set.disk_enc_set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/disk_encryption_set) | resource |
 | [azurerm_key_vault_access_policy.disk_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.disk_enc_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
@@ -52,6 +53,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | [azurerm_virtual_machine_data_disk_attachment.data_disk_attachments](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) | resource |
 | [azurerm_virtual_machine_extension.entra](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) | resource |
 | [azurerm_windows_virtual_machine.winvm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.enc_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 
 ## Inputs
@@ -112,11 +114,14 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 | <a name="input_rc_os_sku"></a> [rc\_os\_sku](#input\_rc\_os\_sku) | The SKU of run command to use. | `string` | `null` | no |
 | <a name="input_rc_script_file"></a> [rc\_script\_file](#input\_rc\_script\_file) | The path to the script file to run against the virtual machine. | `string` | `null` | no |
 | <a name="input_remove_splunk_uf"></a> [remove\_splunk\_uf](#input\_remove\_splunk\_uf) | Remove splunk uniforwarder on the virtual machine. | `bool` | `true` | no |
+| <a name="input_rsv_name"></a> [rsv\_name](#input\_rsv\_name) | Name of the Recovery Services Vault to enroll this VM in. Required when service\_criticality >= 4. | `string` | `null` | no |
+| <a name="input_rsv_resource_group_name"></a> [rsv\_resource\_group\_name](#input\_rsv\_resource\_group\_name) | Resource group name of the Recovery Services Vault. Required when service\_criticality >= 4. | `string` | `null` | no |
 | <a name="input_run_cis"></a> [run\_cis](#input\_run\_cis) | Install CIS hardening using run command script? | `bool` | `false` | no |
 | <a name="input_run_command"></a> [run\_command](#input\_run\_command) | Run a custom command/script against the virtual machine using a run command extension. | `bool` | `false` | no |
 | <a name="input_run_command_sa_key"></a> [run\_command\_sa\_key](#input\_run\_command\_sa\_key) | SA key for the run command | `string` | `""` | no |
 | <a name="input_run_xdr_agent"></a> [run\_xdr\_agent](#input\_run\_xdr\_agent) | Install XDR agents using run command script? | `bool` | `false` | no |
 | <a name="input_run_xdr_collector"></a> [run\_xdr\_collector](#input\_run\_xdr\_collector) | Install XDR collectors using run command script? | `bool` | `false` | no |
+| <a name="input_service_criticality"></a> [service\_criticality](#input\_service\_criticality) | Service criticality rating from 1-5. VMs with criticality >= 4 are enrolled in Recovery Services Vault backup when rsv\_name and rsv\_resource\_group\_name are provided. | `number` | `1` | no |
 | <a name="input_soc_vault_name"></a> [soc\_vault\_name](#input\_soc\_vault\_name) | The name of the SOC Key Vault. | `string` | `"soc-prod"` | no |
 | <a name="input_soc_vault_rg"></a> [soc\_vault\_rg](#input\_soc\_vault\_rg) | The name of the resource group where the SOC Key Vault is located. | `string` | `"soc-core-infra-prod-rg"` | no |
 | <a name="input_splunk_group"></a> [splunk\_group](#input\_splunk\_group) | Splunk universal forwarder global target group. | `string` | `"hmcts_forwarders"` | no |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 
 VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault by providing the vault name and resource group. The backup policy is selected automatically based on criticality. 
 
-To enroll, use recovery service vault module to create the vault and policy and pass the following vars to this module call:
+To enroll, use the [recovery service vault module](https://github.com/hmcts/terraform-module-recovery-services-vault) to create the vault and policy and pass the following vars to this module call:
 
 ```terraform
 module "recovery_services_vault" {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "virtual_machine" {
 }
 ```
 
-Existing callers that do not set `service_criticality`, `rsv_name`, or `rsv_resource_group_name` are unaffected — no backup resources are created.
+Existing module users that do not set `service_criticality`, `rsv_name`, or `rsv_resource_group_name` are unaffected — no backups will be created.
 
 <!-- BEGIN_TF_DOCS -->
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ An example can be found [here](https://github.com/hmcts/terraform-module-virtual
 
 ## Backup Enrollment
 
-VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault by providing the vault name and resource group. The backup policy is selected automatically based on criticality — criticality 4 and 5 use the `vm-crit4-5` policy.
+VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault by providing the vault name and resource group. The backup policy is selected automatically based on criticality. 
+
+To enroll, use recovery service vault module to create the vault and policy and pass the following vars to this module call:
 
 ```terraform
 module "recovery_services_vault" {

--- a/README.md
+++ b/README.md
@@ -22,6 +22,43 @@ module "virtual_machine" {
 ```
 An example can be found [here](https://github.com/hmcts/terraform-module-virtual-machine/tree/master/example).
 
+## Backup Enrollment
+
+VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault by providing the vault name and resource group. The backup policy is selected automatically based on criticality — criticality 4 and 5 use the `vm-crit4-5` policy.
+
+```terraform
+module "recovery_services_vault" {
+  source = "git::https://github.com/hmcts/module-terraform-azurerm-recovery-services-vault.git?ref=main"
+
+  name                = "{var.product}-rsv-{var.env}"
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = var.common_tags
+}
+
+module "virtual_machine" {
+  source = "git::https://github.com/hmcts/terraform-module-virtual-machine.git?ref=master"
+  #...
+
+  service_criticality     = 5
+  rsv_name                = module.recovery_services_vault.recovery_vault_name
+  rsv_resource_group_name = module.recovery_services_vault.recovery_vault_resource_group_name
+}
+```
+
+If the RSV is managed in a separate repository, pass the vault details as plain strings:
+
+```terraform
+module "virtual_machine" {
+  source = "git::https://github.com/hmcts/terraform-module-virtual-machine.git?ref=master"
+  # ...
+  service_criticality     = 5
+  rsv_name                = "<name>"
+  rsv_resource_group_name = "<resource_group>"
+}
+```
+
+Existing callers that do not set `service_criticality`, `rsv_name`, or `rsv_resource_group_name` are unaffected — no backup resources are created.
+
 <!-- BEGIN_TF_DOCS -->
 
 

--- a/backup.tf
+++ b/backup.tf
@@ -1,0 +1,18 @@
+locals {
+  backup_policy_by_criticality = {
+    4 = "vm-crit4-5"
+    5 = "vm-crit4-5"
+  }
+  backup_policy_name       = lookup(local.backup_policy_by_criticality, var.service_criticality, null)
+  enable_backup_enrollment = local.backup_policy_name != null && var.rsv_name != null && var.rsv_resource_group_name != null
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_backup_protected_vm" "main" {
+  count               = local.enable_backup_enrollment ? 1 : 0
+  resource_group_name = var.rsv_resource_group_name
+  recovery_vault_name = var.rsv_name
+  source_vm_id        = lower(var.vm_type) == "windows" ? azurerm_windows_virtual_machine.winvm[0].id : azurerm_linux_virtual_machine.linvm[0].id
+  backup_policy_id    = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.rsv_resource_group_name}/providers/Microsoft.RecoveryServices/vaults/${var.rsv_name}/backupPolicies/${local.backup_policy_name}"
+}

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -482,3 +482,32 @@ variable "azure_monitor_type_handler_version" {
   type        = string
   default     = "1.9"
 }
+
+# --------------------------------------------------
+# BACKUP
+# --------------------------------------------------
+
+variable "service_criticality" {
+  description = "Service criticality rating from 1-5. VMs with criticality >= 4 are enrolled in Recovery Services Vault backup when rsv_name and rsv_resource_group_name are provided."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.service_criticality >= 1 && var.service_criticality <= 5
+    error_message = "Service criticality must be between 1 and 5."
+  }
+}
+
+variable "rsv_name" {
+  description = "Name of the Recovery Services Vault to enroll this VM in. Required when service_criticality >= 4."
+  type        = string
+  default     = null
+}
+
+variable "rsv_resource_group_name" {
+  description = "Resource group name of the Recovery Services Vault. Required when service_criticality >= 4."
+  type        = string
+  default     = null
+}
+
+


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31651

### Change description

- Add feature for enrolment into Recovery Services Vault
- terraform-module-recovery-service-vault needs to be called to create RSV and policy first

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
