### PR TITLE
Manage Entra extension tags

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -5,8 +5,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs inside the README.md and push changes back to PR branch
@@ -14,4 +15,4 @@ jobs:
       with:
         working-dir: .
         config-file: .terraform-docs.yml
-        git-push: "true"
+        git-push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/extensions.tf
+++ b/extensions.tf
@@ -71,6 +71,7 @@ resource "azurerm_virtual_machine_extension" "entra" {
   type                       = "AADSSHLoginForLinux"
   type_handler_version       = var.aad_type_handler_version
   auto_upgrade_minor_version = true
+  tags                       = var.tags
 }
 
 resource "azurerm_role_assignment" "admin-user" {

--- a/provider.tf
+++ b/provider.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
+      version               = ">= 4.48, < 5.0"
       configuration_aliases = [azurerm.cnp, azurerm.soc, azurerm.dcr]
     }
   }


### PR DESCRIPTION
## Change

Pass the module's existing tags input to the Linux AADSSHLoginForLinux extension.

The PR also keeps CI deterministic for this change by:

- constraining AzureRM to the currently supported 4.x series, because the example still uses an argument removed in v5;
- allowing the terraform-docs workflow to check out fork-backed PRs without trying to push to the fork.

## Why

Azure tag inheritance adds the VM tags to this extension, while Terraform currently declares no tags for it. Every subsequent plan therefore proposes removing the inherited tags. Downstream resources which depend on the VM can then acquire unnecessary unknown values and replacement churn.

Managing the same tags explicitly makes the extension converge with the rest of the VM resources.

## Validation

- Terraform workflow: passed
- terraform-docs workflow: passed
- terraform fmt -check -recursive
- terraform -chdir=example validate
- git diff --check

## Downstream

Required by hmcts/ccd-elasticsearch-app#2 to remove repeat-plan drift before promoting the side-by-side cluster beyond demo.
